### PR TITLE
Add ability to specify time at which subreddits can be used for wallpapers

### DIFF
--- a/Reddit Wallpaper Changer/RWC.cs
+++ b/Reddit Wallpaper Changer/RWC.cs
@@ -440,6 +440,7 @@ namespace Reddit_Wallpaper_Changer
             subs = subs.Trim('+');
             var splitList = subs.Split('+').ToList();
 
+            Regex nameTimeRegex = new Regex(@"^(?<name>[^[\]+]+)(?:\[(?<t1>[0-9]{1,2}:[0-9]{2})-(?<t2>[0-9]{1,2}:[0-9]{2})+\])?");
             foreach (var entry in splitList)
             {
                 var r = nameTimeRegex.Match(entry);

--- a/Reddit Wallpaper Changer/RWC.cs
+++ b/Reddit Wallpaper Changer/RWC.cs
@@ -809,6 +809,7 @@ namespace Reddit_Wallpaper_Changer
                 if (subs.Length == 0)
                 {
                     updateStatus("No subreddits available for wallpaper change.");
+                    Logging.LogMessageToFile("No subs to pull wallpapers from. Aborting.", 0);
                     return;
                 }
 

--- a/Reddit Wallpaper Changer/RWC.cs
+++ b/Reddit Wallpaper Changer/RWC.cs
@@ -440,7 +440,6 @@ namespace Reddit_Wallpaper_Changer
             subs = subs.Trim('+');
             var splitList = subs.Split('+').ToList();
 
-            Regex nameTimeRegex = new Regex(@"^(?<name>[a-zA-Z0-9-_%]+)(?:\[(?<t1>[0-9]{1,2}:[0-9]{2})-(?<t2>[0-9]{1,2}:[0-9]{2})+\])?");
             foreach (var entry in splitList)
             {
                 var r = nameTimeRegex.Match(entry);


### PR DESCRIPTION
I had figured that this feature could be useful to some, including myself, and so I had a go at implementing it.

The feature is implemented through the subreddits field by appending an optional time range in the format "[H:mm-H:mm]" (24hr) to a subreddit's name. If the current time is outside of that range, the subreddit is excluded from the selection of subreddits from which wallpapers can be pulled. Entries with malformed time codes are skipped.

To facilitate this, a new parse function has been added. In addition, the changeWallpaper function now quietly returns if no subreddits are available.

An example use case for this might be choosing motivational subreddits in the morning and relaxing subreddits at night. A valid subreddit string could look like, "GetMotivated[5:00-11:30]+EarthPorn[11:30-17:00]+SpacePorn[17:00-5:00]+puppies+wallpapers"