### PR TITLE
ThumbnailCache folder not created on startup

### DIFF
--- a/Reddit Wallpaper Changer/RWC.cs
+++ b/Reddit Wallpaper Changer/RWC.cs
@@ -203,13 +203,15 @@ namespace Reddit_Wallpaper_Changer
         //======================================================================
         private void setupAppDataLocation()
         {
-            if (Properties.Settings.Default.AppDataPath == "")
-            {
-                String appDataFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\Reddit Wallpaper Changer";
-                System.IO.Directory.CreateDirectory(appDataFolderPath);
-                Properties.Settings.Default.AppDataPath = appDataFolderPath;
-                Properties.Settings.Default.Save();
-            }     
+            string appDataFolderPath;
+            if (Properties.Settings.Default.AppDataPath.Any())
+                appDataFolderPath = Properties.Settings.Default.AppDataPath;
+            else
+                appDataFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\Reddit Wallpaper Changer";
+
+            Directory.CreateDirectory(appDataFolderPath);
+            Properties.Settings.Default.AppDataPath = appDataFolderPath;
+            Properties.Settings.Default.Save();  
         }
 
         //======================================================================
@@ -217,13 +219,15 @@ namespace Reddit_Wallpaper_Changer
         //======================================================================
         private void setupThumbnailCache()
         {
-            if (Properties.Settings.Default.thumbnailCache == "")
-            {                
-                String thumbnailCache = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\Reddit Wallpaper Changer\ThumbnailCache";
-                System.IO.Directory.CreateDirectory(thumbnailCache);
-                Properties.Settings.Default.thumbnailCache = thumbnailCache;
-                Properties.Settings.Default.Save();
-            }
+            string thumbnailCachePath;
+            if (Properties.Settings.Default.thumbnailCache.Any())
+                thumbnailCachePath = Properties.Settings.Default.thumbnailCache;
+            else
+                thumbnailCachePath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\Reddit Wallpaper Changer\ThumbnailCache";
+
+            Directory.CreateDirectory(thumbnailCachePath);
+            Properties.Settings.Default.thumbnailCache = thumbnailCachePath;
+            Properties.Settings.Default.Save();
         }
 
 


### PR DESCRIPTION
Hi Paul, I noticed a small issue when installing today. I'm be keen to help out with some bug fixes/new features

The thumbnailCache folder wasn't being created on startup if the folder had been deleted or if the setting already had a valid path.

![thumbnailunavailable](https://user-images.githubusercontent.com/12867537/35479428-2552ea94-045c-11e8-9003-11b43c1c14c3.png)
![appdata](https://user-images.githubusercontent.com/12867537/35479429-257dd560-045c-11e8-970f-6789fb36e9db.png)
[log.txt](https://github.com/Rawns/Reddit-Wallpaper-Changer/files/1670802/log.txt)

I also notice that when instantiating the Database class to set the RWC.database field, the constructor references the AppDataPath setting to set the dbPath, but is being instantiated before RWC_Load where the AppDataPath setting is actually assigned, possibly the cause of issue #78?

![databasecreation](https://user-images.githubusercontent.com/12867537/35479500-e95aa12e-045d-11e8-80f2-69250df577e8.PNG)
![dbpath](https://user-images.githubusercontent.com/12867537/35479501-e984e63c-045d-11e8-9ba1-4b9d1473e809.PNG)
